### PR TITLE
Fix condition to use 'changelog_test' instance variable

### DIFF
--- a/lib/gitbot_backend.rb
+++ b/lib/gitbot_backend.rb
@@ -158,7 +158,7 @@ class GitbotBackend
 
   # this function check if changelog specific test is active.
   def changelog_active(pr)
-    return unless changelog_test
+    return unless @changelog_test
     changelog_changed(@repo, pr)
     true
   end


### PR DESCRIPTION
@MalloZup - What do you think about this? Could this be causing that `changelog_test` is always executed? 