### PR TITLE
Add https support for git operations

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -16,6 +16,7 @@ OPTIONAL Options
     -u, --url TARGET_URL             specify the url to append to github review usually is the jenkins url of the job
         --changelogtest              check if the PR include a changelog entry. Automatically set --file ".changes"
     -C, --check                      check, if a PR requires testRun in checkmode and test if there is a Pull Request which requires a test
+        --https                      If present, use http instead of ssh for git operations
 HELP
     -h, --help                       help
 ************************************************

--- a/lib/git_op.rb
+++ b/lib/git_op.rb
@@ -7,35 +7,40 @@ require 'timeout'
 # git operation for gitbot
 class GitOp
   attr_reader :git_dir, :pr, :pr_fix, :repo_external
-  def initialize(git_dir, pr)
+  def initialize(git_dir, pr, options)
     @git_dir = git_dir
     # prefix for the test pr that gitbot tests.
     @pr_fix = 'PR-'
     # pr object for extract all relev. data.
     @pr = pr
+    # All GitBot options
+    @options = options
     # object to handle external repos
-    @repo_external = ExternalRepoGit.new(pr)
+    @repo_external = ExternalRepoGit.new(pr, options)
+    puts @options[:https]
   end
 
-  def ck_or_clone_git(repo)
+  def ck_or_clone_git
     return if File.directory?(git_dir)
     FileUtils.mkdir_p(git_dir)
     Dir.chdir git_dir
-    puts `git clone git@github.com:#{repo}.git`
+    repo_url = @options[:https] ? 'https://github.com/' : 'git@github.com:'
+    repo_url = "#{repo_url}#{@options[:repo]}.git"
+    puts `git clone #{repo_url}`
   end
 
   # this function merge the pr branch  into target branch,
   # where the author of pr wanted to submit
-  def goto_prj_dir(repo)
-    git_repo_dir = git_dir + '/' + repo.split('/')[1]
+  def goto_prj_dir
+    git_repo_dir = git_dir + '/' + @options[:repo].split('/')[1]
     # chech that dir exist, otherwise clone it
-    ck_or_clone_git(repo)
+    ck_or_clone_git
     begin
       # /tmp/gitbot, this is in case the dir already exists
       Dir.chdir git_repo_dir
     rescue Errno::ENOENT
       # this is in case we clone the repo
-      Dir.chdir repo.split('/')[1]
+      Dir.chdir @options[:repo].split('/')[1]
     end
   end
 
@@ -52,8 +57,8 @@ class GitOp
   end
 
   # merge pr_branch into upstream targeted branch
-  def merge_pr_totarget(upstream, pr_branch, repo)
-    goto_prj_dir(repo)
+  def merge_pr_totarget(upstream, pr_branch)
+    goto_prj_dir
     check_git_dir
     `git checkout #{upstream}`
     check_duplicata_pr_branch("#{pr_fix}#{pr_branch}")
@@ -79,10 +84,11 @@ end
 # PR repo:  MyUSER/gitbot
 class ExternalRepoGit
   attr_reader :pr, :rem_repo, :pr_fix
-  def initialize(pr)
+  def initialize(pr, options)
     # pr object for extract all relev. data.
     @pr = pr
     @pr_fix = 'PR-'
+    @options = options
   end
 
   def checkout_into
@@ -104,7 +110,8 @@ class ExternalRepoGit
   end
 
   def add_remote(rem_repo)
-    puts `git remote add #{rem_repo} #{pr.head.repo.ssh_url}`
+    repo_url = @options[:https] ? pr.head.repo.html_url : pr.head.repo.ssh_url
+    puts `git remote add #{rem_repo} #{repo_url}`
   end
 
   def fetch_remote(rem_repo)

--- a/lib/opt_parser.rb
+++ b/lib/opt_parser.rb
@@ -25,6 +25,12 @@ class OptParserInternal
     end
   end
 
+  def https_opt(opt)
+    @options[:https] = false
+    https_desc = 'If present, use https instead of ssh for git operations'
+    opt.on('--https', https_desc) { |https| @options[:https] = https }
+  end
+
   def changelog_opt(opt)
     changelog_desc = 'check if the PR include a changelog entry' \
     ' Automatically set --file \".changes\"'
@@ -48,6 +54,7 @@ class OptParserInternal
     changelog_opt(opt)
     url_opt(opt)
     pr_number(opt)
+    https_opt(opt)
   end
 
   # primary

--- a/tests/acceptance_tests/prs_operations.rb
+++ b/tests/acceptance_tests/prs_operations.rb
@@ -7,6 +7,7 @@ require 'English'
 class GitRemoteOperations
   attr_reader :repo, :client
   def initialize(repo)
+    @script = '../../gitbot.rb'
     @repo = repo
     @client = Octokit::Client.new(netrc: true)
     Octokit.auto_paginate = true
@@ -57,8 +58,22 @@ class GitbotTesting
     num = 30
     `echo '#! /bin/bash' > #{valid_test}`
     `chmod +x #{valid_test}`
-    puts `ruby  ../../gitbot.rb -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} -P #{num}`
+    puts `ruby #{script} -r #{repo} -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} -P #{num}`
     raise 'BASIC TEST FAILED' if $CHILD_STATUS.exitstatus.nonzero?
+  end
+
+  def basic_https
+    context = 'changelog'
+    desc = 'dev-test'
+    git_dir = '/tmp/ruby312'
+    valid_test = '/tmp/gitbot.sh'
+    url = 'https://github.com/openSUSE/gitbot/pull/8'
+    ftype = '.rb'
+    num = 30
+    `echo '#! /bin/bash' > #{valid_test}`
+    `chmod +x #{valid_test}`
+    puts `ruby #{script} -r #{repo} -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} -P #{num} --https`
+    raise 'BASIC HTTPS TEST FAILED' if $CHILD_STATUS.exitstatus.nonzero?
   end
 
   def basic_check_test
@@ -72,11 +87,11 @@ class GitbotTesting
     ftype = '.rb'
     `echo '#! /bin/bash' > #{valid_test}`
     `chmod +x #{valid_test}`
-    puts `ruby  ../../gitbot.rb -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} -C`
+    puts `ruby #{script} -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} -C`
     # with check we have -1 has value ( used for retrigger)
     raise 'BASIC TEST CHECK FAILED' if $CHILD_STATUS.exitstatus.zero?
     # FIXME: we should check that the given context contain a pending status
-    puts `ruby  ../../gitbot.rb -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype}`
+    puts `ruby #{script} -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype}`
   end
 
   def changelog_should_fail(com_st)
@@ -88,8 +103,8 @@ class GitbotTesting
     ftype = '.rb'
     `echo '#! /bin/bash' > #{valid_test}`
     `chmod +x #{valid_test}`
-    puts `ruby  ../../gitbot.rb -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} --changelogtest`
-    raise 'chanelog test should fail!' unless  failed_status(com_st, context)
+    puts `ruby #{script} -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} --changelogtest`
+    raise 'chanelog test should fail!' unless failed_status(com_st, context)
   end
 
   def changelog_should_pass(com_st)
@@ -101,7 +116,7 @@ class GitbotTesting
     ftype = '.rb'
     `echo '#! /bin/bash' > #{valid_test}`
     `chmod +x #{valid_test}`
-    puts `ruby  ../../gitbot.rb -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} --changelogtest`
+    puts `ruby #{script} -r #{repo}  -c #{context} -d #{desc} -g #{git_dir} -t #{valid_test} -f #{ftype} -u #{url} --changelogtest`
     raise 'chanelog test should pass!' if failed_status(com_st, context)
   end
 

--- a/tests/unit_tests/t_git_operation.rb
+++ b/tests/unit_tests/t_git_operation.rb
@@ -7,13 +7,13 @@ class GitbotGitop < Minitest::Test
   def test_gitop
     @full_hash = { repo: 'openSUSE/gitbot', context: 'python-t', description:
                    'functional', test_file: 'gino.sh', file_type: '.sh',
-                   git_dir: 'gitty' }
+                   git_dir: 'gitty', https: false }
     gb = GitbotBackend.new(@full_hash)
     # crate fake object for internal class external repo
     # FIXME: this could improved creating a full mock obj
     pr = 'fake'
-    gop = GitOp.new(gb.git_dir, pr)
+    gop = GitOp.new(gb.git_dir, pr, @full_hash)
     puts gb.git_dir
-    gop.ck_or_clone_git(gb.repo)
+    gop.ck_or_clone_git
   end
 end


### PR DESCRIPTION
HTTPS can be enabled by using the switch --https (otherwise the gitbot will use SSH as it does currently).

This is useful to avoid any SSH configuration when using GitBot with public projects.