### PR TITLE
Implement changelog split/merge mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog Gitarro
 
+## 0.1.91
+
+- Fix typo in 'faraday' entry in the Gemfile
+
 ## 0.1.90
 
 - Don't uncheck re-run boxes in check mode as those will be checked again in the next gitarro run triggering the test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.91
 
+- Implement split/merge method in the changelog test
 - Fix typo in 'faraday' entry in the Gemfile
 
 ## 0.1.90

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'english'
-gem 'farday', '<= 1.10.2'
+gem 'faraday', '<= 1.10.2'
 gem 'faraday-net_http', '<= 2.1.0'
 gem 'minitest'
 gem 'minitest-reporters'


### PR DESCRIPTION
Implement changelog split/merge mechanism in the `changelog_test` script to address changelog file conflict issues.

*Original issue description:*
> It's a recurrent problem that will only get worse with the team growing.
> 
> Every time we backport a commit or a PR is merged there is a big chance that it will cause a file conflict in all the other open PRs. This can be quite annoying and time-consuming because we need to rebase manually and wait for the CI to run again. 
> 
> What about having a dedicated changes file per person/feature and then merge everything during release time?
> 
> Example before release:
> 
> spacewalk-web.changes.lneves.clm
> spacewalk-web.changes.lneves.channels
> spacewalk-web.changes.julio.release_something
> 
> After Release:
> merge everything into the top spacewalk-web.changes and remove the files.
> 
> This might need some work to adapt tools like TITO, but it will save up A LOT of time in the future for everyone.

Fixes https://github.com/SUSE/spacewalk/issues/9010